### PR TITLE
Perform SIGTERM handling and upgrade redis, python, honcho

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ ADD stunnel.conf /stunnel.conf
 ADD Procfile /Procfile
 
 WORKDIR /
-CMD PYTHONUNBUFFERED=1 honcho start
+ENV PYTHONUNBUFFERED=1
+CMD ["honcho", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM redis:4.0.11
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y stunnel python-pip && \
+    apt-get install -y stunnel python3-pip && \
     rm -rf /var/lib/apt/lists/*
-RUN pip install honcho
+RUN pip3 install honcho
 
 ADD stunnel.conf /stunnel.conf
 ADD Procfile /Procfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ADD stunnel.conf /stunnel.conf
 ADD Procfile /Procfile
 
 WORKDIR /
-CMD honcho start
+CMD PYTHONUNBUFFERED=1 honcho start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM redis
+FROM redis:4.0.11
 
 RUN apt-get update --fix-missing && \
     apt-get install -y stunnel python-pip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM redis:4.0.11
+FROM redis
 
 RUN apt-get update --fix-missing && \
     apt-get install -y stunnel python3-pip && \


### PR DESCRIPTION
- [x] Make honcho respond to SIGTERM. Fixes #1 
- [x] Explicitly specify redis version. Fixes #2 
- [x] Un buffer output of honcho. Refer [this issue](https://github.com/nickstenning/honcho/issues/136) in honcho repo
- [x] Use python 3 instead of python 2 for honcho