### PR TITLE
Use redis 5 in alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-FROM redis
+FROM redis:5-alpine
 
-RUN apt-get update --fix-missing && \
-    apt-get install -y stunnel python3-pip && \
-    rm -rf /var/lib/apt/lists/*
-RUN pip3 install honcho
-
-ADD stunnel.conf /stunnel.conf
-ADD Procfile /Procfile
+RUN apk add --no-cache \
+    stunnel~=5.48 \
+    python3~=3.7 \
+    && pip3 install honcho==1.0.*
 
 WORKDIR /
+COPY stunnel.conf Procfile /
+
 ENV PYTHONUNBUFFERED=1
 CMD ["honcho", "start"]

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-stunnel: stunnel4 /stunnel.conf
+stunnel: stunnel /stunnel.conf
 redis: /usr/local/bin/redis-server --port 6380 --bind 0.0.0.0


### PR DESCRIPTION
This will save a lot of space and build is much faster

```
REPOSITORY     TAG     IMAGE ID            CREATED              SIZE
rtls           alpine  589eb02796f3        4 seconds ago        83.3MB
rtls           debian  178794f36dae        About a minute ago   500MB
```

I have also fixed all linting issues according to [hadolint](https://github.com/hadolint/hadolint).
